### PR TITLE
Fix フレンドが居ない時に起動すると落ちる

### DIFF
--- a/source/AlphaMainPage.cs
+++ b/source/AlphaMainPage.cs
@@ -341,7 +341,7 @@ namespace keep.grass
 				CircleGraph.SetStartAngle(TimeToAngle(Now));
 				CircleGraph.Data = MakeSlices(LeftTime, LeftTimeColor);
 
-				if (Friends.Any())
+				if (Friends?.Any() ?? false)
 				{
 					CircleGraph.SatelliteTexts = null;
 				}


### PR DESCRIPTION
フレンド（ライバル）が未登録な時に、アプリを起動すると↓の例外で落ちてたのを修正しました。

```
Xamarin caused by: android.runtime.JavaProxyThrowable: System.ArgumentNullException: Value cannot be null.
Parameter name: source
  at System.Linq.Enumerable.Any[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x00010] in <74020637048f40ef83ab815344bf9b7f>:0 
  at keep.grass.AlphaMainPage+<UpdateLeftTime>c__async1.MoveNext () [0x001c4] in <ef5e57d7107b4186897ad9cc72f68d1f>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at keep.grass.AlphaMainPage+<StartUpdateLeftTimeTask>c__asyncA.MoveNext () [0x00065] in <ef5e57d7107b4186897ad9cc72f68d1f>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore.<ThrowAsync>m__0 (System.Object state) [0x00000] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at Android.App.SyncContext+<Post>c__AnonStorey0.<>m__0 () [0x00000] in <a2bffeb1856b49ff8dbe7efc6f5855b7>:0 
  at Java.Lang.Thread+RunnableImplementor.Run () [0x0000b] in <a2bffeb1856b49ff8dbe7efc6f5855b7>:0 
  at Java.Lang.IRunnableInvoker.n_Run (System.IntPtr jnienv, System.IntPtr native__this) [0x00009] in <a2bffeb1856b49ff8dbe7efc6f5855b7>:0 
  at (wrapper dynamic-method) System.Object:05f7ff0b-2392-4efc-b6aa-c0a896a94a0c (intptr,intptr)
	at mono.java.lang.RunnableImplementor.n_run(Native Method)
	at mono.java.lang.RunnableImplementor.run(RunnableImplementor.java:30)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:234)
	at android.app.ActivityThread.main(ActivityThread.java:5526)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```