### PR TITLE
[Android]Fix アプリ画面が破棄された後、通知表示時に落ちる

### DIFF
--- a/source/AlphaMainPage.cs
+++ b/source/AlphaMainPage.cs
@@ -341,7 +341,7 @@ namespace keep.grass
 				CircleGraph.SetStartAngle(TimeToAngle(Now));
 				CircleGraph.Data = MakeSlices(LeftTime, LeftTimeColor);
 
-				if (Friends.Any())
+				if (Friends?.Any() ?? false)
 				{
 					CircleGraph.SatelliteTexts = null;
 				}

--- a/source/Droid/AlarmIntentService.cs
+++ b/source/Droid/AlarmIntentService.cs
@@ -14,24 +14,24 @@ namespace keep.grass.Droid
 			Debug.WriteLine("AlarmIntentService::OnHandleIntent()");
 			try
 			{
-				ShowNotification(ApplicationContext, intent);
+				ShowNotification(intent);
 			}
 			finally
 			{
 				Android.Support.V4.Content.WakefulBroadcastReceiver.CompleteWakefulIntent(intent);
 			}
 		}
-		public void ShowNotification(Context context, Intent intent)
+		public void ShowNotification(Intent intent)
 		{
 			var id = intent.GetIntExtra("id", 0);
 			var title = intent.GetStringExtra("title");
 			var body = intent.GetStringExtra("message");
 
-			var main_intent = new Intent(context, typeof(MainActivity));
+			var main_intent = new Intent(this, typeof(MainActivity));
 			main_intent.PutExtra("type", "alarm");
 			main_intent.PutExtra("id", id);
 
-			var builder = new Notification.Builder(Forms.Context);
+			var builder = new Notification.Builder(this);
 			//builder.SetGroup("keep.grass");
 			builder.SetTicker(title);
 			builder.SetContentTitle(title);
@@ -40,18 +40,18 @@ namespace keep.grass.Droid
 			(
 				PendingIntent.GetActivity
 				(
-					context,
+					this,
 					id,
 					main_intent,
 					PendingIntentFlags.UpdateCurrent
 				)
 			);
 			builder.SetSmallIcon(Resource.Drawable.icon);
-			builder.SetLargeIcon(BitmapFactory.DecodeResource(context.Resources, Resource.Drawable.icon));
+			builder.SetLargeIcon(BitmapFactory.DecodeResource(this.Resources, Resource.Drawable.icon));
 			builder.SetDefaults(NotificationDefaults.All);
 			builder.SetAutoCancel(true);
 
-			((NotificationManager)context.GetSystemService(NotificationService))
+			((NotificationManager)this.GetSystemService(NotificationService))
 				.Notify(id, builder.Build());
 		}
 	}


### PR DESCRIPTION
Android で、アプリを終了して少し(5分くらい)放置した後で、定刻通知が出るタイミングでエラーが発生して、それ以降、通知がこなくなるのを修正しました。

Android の Service は、それ自体が Context なので、 ``Forms.Context`` や ``ApplicationContext`` を使う必要はないと思います。特に ``Forms.Context`` は、アプリ画面が起動されないと有効でないと思います。

```
java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.pm.ApplicationInfo android.content.Context.getApplicationInfo()' on a null object reference
	at android.app.Notification$Builder.<init>(Notification.java:2168)
	at md5f652f176cf734a8b581c8e6a100127ab.AlarmIntentService.n_onHandleIntent(Native Method)
	at md5f652f176cf734a8b581c8e6a100127ab.AlarmIntentService.onHandleIntent(AlarmIntentService.java:46)
	at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:66)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:234)
	at android.os.HandlerThread.run(HandlerThread.java:61)
Xamarin caused by: Java.Lang.NullPointerException: Attempt to invoke virtual method 'android.content.pm.ApplicationInfo android.content.Context.getApplicationInfo()' on a null object reference
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at Java.Interop.JniEnvironment+InstanceMethods.CallNonvirtualVoidMethod (Java.Interop.JniObjectReference instance, Java.Interop.JniObjectReference type, Java.Interop.JniMethodInfo method, Java.Interop.JniArgumentValue* args) [0x000a7] in <a043032cf94a485190047a14918b9f60>:0 
  at Java.Interop.JniPeerMembers+JniInstanceMethods.FinishCreateInstance (System.String constructorSignature, Java.Interop.IJavaPeerable self, Java.Interop.JniArgumentValue* parameters) [0x0005e] in <a043032cf94a485190047a14918b9f60>:0 
  at Android.App.Notification+Builder..ctor (Android.Content.Context context) [0x00082] in <a2bffeb1856b49ff8dbe7efc6f5855b7>:0 
  at keep.grass.Droid.AlarmIntentService.ShowNotification (Android.Content.Context context, Android.Content.Intent intent) [0x0005a] in <054122c2c5f94192a3bd7b98d676d2ef>:0 
  at keep.grass.Droid.AlarmIntentService.OnHandleIntent (Android.Content.Intent intent) [0x00013] in <054122c2c5f94192a3bd7b98d676d2ef>:0 
  at Android.App.IntentService.n_OnHandleIntent_Landroid_content_Intent_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_intent) [0x00011] in <a2bffeb1856b49ff8dbe7efc6f5855b7>:0 
  at (wrapper dynamic-method) System.Object:ce5d9e24-742b-459e-8160-e9ccb260be75 (intptr,intptr,intptr)
  --- End of managed Java.Lang.NullPointerException stack trace ---
java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.pm.ApplicationInfo android.content.Context.getApplicationInfo()' on a null object reference
	at android.app.Notification$Builder.<init>(Notification.java:2168)
	at md5f652f176cf734a8b581c8e6a100127ab.AlarmIntentService.n_onHandleIntent(Native Method)
	at md5f652f176cf734a8b581c8e6a100127ab.AlarmIntentService.onHandleIntent(AlarmIntentService.java:46)
	at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:66)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:234)
	at android.os.HandlerThread.run(HandlerThread.java:61)
```