### PR TITLE
[Android]Fix 残り時間通知時に画面が起動されてないと MUST call Xamarin.Forms.Init で落ちる

### DIFF
--- a/source/Droid/UpdateIntentService.cs
+++ b/source/Droid/UpdateIntentService.cs
@@ -9,25 +9,32 @@ namespace keep.grass.Droid
 	[Service]
 	public class UpdateIntentService :IntentService
 	{
+		public override void OnCreate()
+		{
+			base.OnCreate();
+			global::Xamarin.Forms.Forms.Init(this, null);
+		}
+
 		protected override void OnHandleIntent(Intent intent)
 		{
 			Debug.WriteLine("UpdateIntentService::OnHandleIntent()");
 			try
 			{
-				UpdateLastPublicActivity(ApplicationContext, intent);
+				UpdateLastPublicActivity(intent);
 			}
 			finally
 			{
 				Android.Support.V4.Content.WakefulBroadcastReceiver.CompleteWakefulIntent(intent);
 			}
 		}
-		public void UpdateLastPublicActivity(Context context, Intent intent)
+
+		void UpdateLastPublicActivity(Intent intent)
 		{
 			OmegaFactory.MakeSureInit();
 			var Domain = AlphaFactory.MakeSureDomain() as OmegaDomain;
 			try
 			{
-				Domain.ThreadContext.Value = context;
+				Domain.ThreadContext.Value = this;
 				Domain.AutoUpdateLastPublicActivityAsync().Wait();
 			}
 			finally


### PR DESCRIPTION
#2 と同様、残り時間の通知でも、画面が破棄されている状態だとエラーになります。
原因は、MainActivity を使用しないので ``Xamarin.Forms.Init()`` が呼ばれないためです。

``UpdateIntentService`` は Android 固有の処理なので、本来は Xamarin.Forms に依存しないのが望ましいと思われますが、とりあえず Service の Create で MainActivity と同じように Forms.Init するようにしました。

```
Xamarin caused by: android.runtime.JavaProxyThrowable: System.AggregateException: One or more errors occurred. ---> System.InvalidOperationException: You MUST call Xamarin.Forms.Init(); prior to using it.
  at Xamarin.Forms.Device.get_PlatformServices () [0x00007] in <b0fc14d4e5b04749b7241d1235a68329>:0 
  at Xamarin.Forms.Device.BeginInvokeOnMainThread (System.Action action) [0x00000] in <b0fc14d4e5b04749b7241d1235a68329>:0 
  at keep.grass.AlphaDomain.OnEndQuery () [0x00019] in <28b6f6202b824c7aacdc7acc06f9c4da>:0 
  at keep.grass.AlphaDomain+<UpdateLastPublicActivityAsync>c__async2.MoveNext () [0x00180] in <28b6f6202b824c7aacdc7acc06f9c4da>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at keep.grass.AlphaDomain+<AutoUpdateLastPublicActivityAsync>c__async0.MoveNext () [0x00081] in <28b6f6202b824c7aacdc7acc06f9c4da>:0 
   --- End of inner exception stack trace ---
  at System.Threading.Tasks.Task.ThrowIfExceptional (System.Boolean includeTaskCanceledExceptions) [0x00014] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Threading.Tasks.Task.Wait (System.Int32 millisecondsTimeout, System.Threading.CancellationToken cancellationToken) [0x00052] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Threading.Tasks.Task.Wait () [0x00000] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at keep.grass.Droid.UpdateIntentService.UpdateLastPublicActivity (Android.Content.Context context, Android.Content.Intent intent) [0x00024] in <e963bd2d40374b3f81238addb2dd73f3>:0 
  at keep.grass.Droid.UpdateIntentService.OnHandleIntent (Android.Content.Intent intent) [0x00013] in <e963bd2d40374b3f81238addb2dd73f3>:0 
  at Android.App.IntentService.n_OnHandleIntent_Landroid_content_Intent_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_intent) [0x00011] in <a2bffeb1856b49ff8dbe7efc6f5855b7>:0 
  at (wrapper dynamic-method) System.Object:4cac9814-9b16-459a-8726-4c88c411cd22 (intptr,intptr,intptr)
---> (Inner Exception #0) System.InvalidOperationException: You MUST call Xamarin.Forms.Init(); prior to using it.
  at Xamarin.Forms.Device.get_PlatformServices () [0x00007] in <b0fc14d4e5b04749b7241d1235a68329>:0 
  at Xamarin.Forms.Device.BeginInvokeOnMainThread (System.Action action) [0x00000] in <b0fc14d4e5b04749b7241d1235a68329>:0 
  at keep.grass.AlphaDomain.OnEndQuery () [0x00019] in <28b6f6202b824c7aacdc7acc06f9c4da>:0 
  at keep.grass.AlphaDomain+<UpdateLastPublicActivityAsync>c__async2.MoveNext () [0x00180] in <28b6f6202b824c7aacdc7acc06f9c4da>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <b2babb3b399b446cba8a66e5b9c28322>:0 
  at keep.grass.AlphaDomain+<AutoUpdateLastPublicActivityAsync>c__async0.MoveNext () [0x00081] in <28b6f6202b824c7aacdc7acc06f9c4da>:0 <---

	at md5f652f176cf734a8b581c8e6a100127ab.UpdateIntentService.n_onHandleIntent(Native Method)
	at md5f652f176cf734a8b581c8e6a100127ab.UpdateIntentService.onHandleIntent(UpdateIntentService.java:37)
	at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:66)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:234)
	at android.os.HandlerThread.run(HandlerThread.java:61)
```